### PR TITLE
Add `guess_current()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,20 @@ pub fn find<S: AsRef<str>>(target_triple: S) -> Option<&'static Platform> {
         .iter()
         .find(|platform| platform.target_triple == target_triple.as_ref())
 }
+
+/// Attempt to guess the current `Platform`. May give inaccurate results.
+pub fn guess_current() -> Option<&'static Platform> {
+    ALL_PLATFORMS.iter().find(|platform| {
+        platform.target_arch == TARGET_ARCH
+            && platform.target_env == TARGET_ENV
+            && platform.target_os == TARGET_OS
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn guesses_current() {
+        assert!(super::guess_current().is_some());
+    }
+}


### PR DESCRIPTION
Attempts to "guess" the current platform by comparing the target attributes to available platforms.

May give inaccurate results. Possibly not even a good idea.