### PR TITLE
Update platforms to match RustForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ please use those for build purposes.
 | target triple                     | target_arch | target_os  | target_env |
 |-----------------------------------|-------------|------------|------------|
 | [aarch64-apple-ios]               | aarch64     | ios        | ""         |
-| [aarch64-unknown-cloudabi]        | aarch64     | cloudabi   | ""         |
 | [aarch64-linux-android]           | aarch64     | android    | ""         |
-| [aarch64-unknown-fuchsia]         | aarch64     | fuchsia    | ""         |
+| [aarch64-fuchsia]                 | aarch64     | fuchsia    | ""         |
 | [aarch64-unknown-linux-gnu]       | aarch64     | linux      | gnu        |
 | [aarch64-unknown-linux-musl]      | aarch64     | linux      | musl       |
 | [arm-linux-androideabi]           | arm         | android    | ""         |
@@ -71,7 +70,6 @@ please use those for build purposes.
 | [armv5te-unknown-linux-gnueabi]   | arm         | linux      | gnu        |
 | [armv7-apple-ios]                 | arm         | ios        | ""         |
 | [armv7-linux-androideabi]         | arm         | android    | ""         |
-| [armv7-unknown-cloudabi-eabihf]   | arm         | cloudabi   | ""         |
 | [armv7-unknown-linux-gnueabihf]   | arm         | linux      | gnu        |
 | [armv7-unknown-linux-musleabihf]  | arm         | linux      | musl       |
 | [armv7s-apple-ios]                | arm         | ios        | ""         |
@@ -81,7 +79,6 @@ please use those for build purposes.
 | [i586-unknown-linux-gnu]          | x86         | linux      | gnu        |
 | [i586-unknown-linux-musl]         | x86         | linux      | gnu        |
 | [i686-linux-android]              | x86         | android    | ""         |
-| [i686-unknown-cloudabi]           | x86         | cloudabi   | ""         |
 | [i686-unknown-freebsd]            | x86         | freebsd    | ""         |
 | [i686-unknown-linux-musl]         | x86         | linux      | musl       |
 | [mips-unknown-linux-gnu]          | mips        | linux      | gnu        |
@@ -104,11 +101,16 @@ please use those for build purposes.
 | [x86_64-sun-solaris]              | x86_64      | solaris    | ""         |
 | [x86_64-unknown-cloudabi]         | x86_64      | cloudabi   | ""         |
 | [x86_64-unknown-freebsd]          | x86_64      | freebsd    | ""         |
-| [x86_64-unknown-fuchsia]          | x86_64      | fuchsia    | ""         |
+| [x86_64-fuchsia]                  | x86_64      | fuchsia    | ""         |
 | [x86_64-unknown-linux-gnux32]     | x86_64      | linux      | gnu        |
 | [x86_64-unknown-linux-musl]       | x86_64      | linux      | musl       |
 | [x86_64-unknown-netbsd]           | x86_64      | netbsd     | ""         |
 | [x86_64-unknown-redox]            | x86_64      | redox      | ""         |
+| [aarch64-unknown-cloudabi]        | aarch64     | cloudabi   | ""         |
+| [armv7-unknown-cloudabi-eabihf]   | arm         | cloudabi   | ""         |
+| [i686-unknown-cloudabi]           | x86         | cloudabi   | ""         |
+| [powerpc-unknown-linux-gnuspe]    | powerpc     | linux      | gnu        |
+| [sparc-unknown-linux-gnu]         | sparc       | linux      | gnu        |
 
 ### Tier 3
 
@@ -116,15 +118,15 @@ please use those for build purposes.
 |-----------------------------------|-------------|------------|------------|
 | [i686-unknown-haiku]              | x86         | haiku      | ""         |
 | [i686-unknown-netbsd]             | x86         | netbsd     | ""         |
-| [le32-unknown-nacl]               | unknown     | unknown    | ""         |
 | [mips-unknown-linux-uclibc]       | mips        | linux      | uclibc     |
 | [mipsel-unknown-linux-uclibc]     | mips        | linux      | uclibc     |
 | [msp430-none-elf]                 | msp430      | unknown    | ""         |
 | [sparc64-unknown-netbsd]          | sparc64     | netbsd     | ""         |
-| [thumbv6m-none-eabi]              | unknown     | unknown    | ""         |
-| [thumbv7em-none-eabi]             | unknown     | unknown    | ""         |
-| [thumbv7em-none-eabihf]           | unknown     | unknown    | ""         |
-| [thumbv7m-none-eabi]              | unknown     | unknown    | ""         |
+| [thumbv6m-none-eabi]              | thumbv6     | unknown    | ""         |
+| [thumbv7em-none-eabi]             | thumbv7     | unknown    | ""         |
+| [thumbv7em-none-eabihf]           | thumbv7     | unknown    | ""         |
+| [thumbv7m-none-eabi]              | thumbv7     | unknown    | ""         |
+| [x86_64-fortanix-unknown-sgx]     | x86_64      | unknown    | sgx        |
 | [x86_64-unknown-bitrig]           | x86_64      | bitrig     | ""         |
 | [x86_64-unknown-dragonfly]        | x86_64      | dragonfly  | ""         |
 | [x86_64-unknown-haiku]            | x86_64      | haiku      | ""         |
@@ -139,9 +141,8 @@ please use those for build purposes.
 [x86_64-pc-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.X86_64_PC_WINDOWS_MSVC.html
 [x86_64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.X86_64_UNKNOWN_LINUX_GNU.html
 [aarch64-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_APPLE_IOS.html
-[aarch64-unknown-cloudabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_UNKNOWN_CLOUDABI.html
 [aarch64-linux-android]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_LINUX_ANDROID.html
-[aarch64-unknown-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_UNKNOWN_FUCHSIA.html
+[aarch64-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_FUCHSIA.html
 [aarch64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_UNKNOWN_LINUX_GNU.html
 [aarch64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_UNKNOWN_LINUX_MUSL.html
 [arm-linux-androideabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARM_LINUX_ANDROIDEABI.html
@@ -152,7 +153,6 @@ please use those for build purposes.
 [armv5te-unknown-linux-gnueabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV5TE_UNKNOWN_LINUX_GNUEABI.html
 [armv7-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV7_APPLE_IOS.html
 [armv7-linux-androideabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV7_LINUX_ANDROIDEABI.html
-[armv7-unknown-cloudabi-eabihf]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV7_UNKNOWN_CLOUDABI_EABIHF.html
 [armv7-unknown-linux-gnueabihf]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV7_UNKNOWN_LINUX_GNUEABIHF.html
 [armv7-unknown-linux-musleabihf]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV7_UNKNOWN_LINUX_MUSLEABIHF.html
 [armv7s-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV7S_APPLE_IOS.html
@@ -162,7 +162,6 @@ please use those for build purposes.
 [i586-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.I586_UNKNOWN_LINUX_GNU.html
 [i586-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.I586_UNKNOWN_LINUX_MUSL.html
 [i686-linux-android]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.I686_LINUX_ANDROID.html
-[i686-unknown-cloudabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.I686_UNKNOWN_CLOUDABI.html
 [i686-unknown-freebsd]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.I686_UNKNOWN_FREEBSD.html
 [i686-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.I686_UNKNOWN_LINUX_MUSL.html
 [mips-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.MIPS_UNKNOWN_LINUX_GNU.html
@@ -185,14 +184,18 @@ please use those for build purposes.
 [x86_64-sun-solaris]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_SUN_SOLARIS.html
 [x86_64-unknown-cloudabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_UNKNOWN_CLOUDABI.html
 [x86_64-unknown-freebsd]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_UNKNOWN_FREEBSD.html
-[x86_64-unknown-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_UNKNOWN_FUCHSIA.html
+[x86_64-fuchsia]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_FUCHSIA.html
 [x86_64-unknown-linux-gnux32]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_UNKNOWN_LINUX_GNUX32.html
 [x86_64-unknown-linux-musl]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_UNKNOWN_LINUX_MUSL.html
 [x86_64-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_UNKNOWN_NETBSD.html
 [x86_64-unknown-redox]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.X86_64_UNKNOWN_REDOX.html
+[aarch64-unknown-cloudabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_UNKNOWN_CLOUDABI.html
+[armv7-unknown-cloudabi-eabihf]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.ARMV7_UNKNOWN_CLOUDABI_EABIHF.html
+[i686-unknown-cloudabi]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.I686_UNKNOWN_CLOUDABI.html
+[powerpc-unknown-linux-gnuspe]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.POWERPC_UNKNOWN_LINUX_GNUSPE.html
+[sparc-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.SPARC_UNKNOWN_LINUX_GNU.html
 [i686-unknown-haiku]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.I686_UNKNOWN_HAIKU.html
 [i686-unknown-netbsd]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.I686_UNKNOWN_NETBSD.html
-[le32-unknown-nacl]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.LE32_UNKNOWN_NACL.html
 [mips-unknown-linux-uclibc]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.MIPS_UNKNOWN_LINUX_UCLIBC.html
 [mipsel-unknown-linux-uclibc]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.MIPSEL_UNKNOWN_LINUX_UCLIBC.html
 [msp430-none-elf]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.MSP430_NONE_ELF.html
@@ -201,6 +204,7 @@ please use those for build purposes.
 [thumbv7em-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.THUMBV7EM_NONE_EABI.html
 [thumbv7em-none-eabihf]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.THUMBV7EM_NONE_EABIHF.html
 [thumbv7m-none-eabi]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.THUMBV7M_NONE_EABI.html
+[x86_64-fortanix-unknown-sgx]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.X86_64_FORTANIX_UNKNOWN_SGX.html
 [x86_64-unknown-bitrig]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.X86_64_UNKNOWN_BITRIG.html
 [x86_64-unknown-dragonfly]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.X86_64_UNKNOWN_DRAGONFLY.html
 [x86_64-unknown-haiku]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.X86_64_UNKNOWN_HAIKU.html

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -53,6 +53,7 @@ pub struct Platform {
 
 /// All valid Rust platforms usable from the mainline compiler
 pub const ALL_PLATFORMS: &[Platform] = &[
+    // Tier 1
     tier1::I686_APPLE_DARWIN,
     tier1::I686_PC_WINDOWS_GNU,
     tier1::I686_PC_WINDOWS_MSVC,
@@ -61,10 +62,10 @@ pub const ALL_PLATFORMS: &[Platform] = &[
     tier1::X86_64_PC_WINDOWS_GNU,
     tier1::X86_64_PC_WINDOWS_MSVC,
     tier1::X86_64_UNKNOWN_LINUX_GNU,
+    // Tier 2
     tier2::AARCH64_APPLE_IOS,
-    tier2::AARCH64_UNKNOWN_CLOUDABI,
     tier2::AARCH64_LINUX_ANDROID,
-    tier2::AARCH64_UNKNOWN_FUCHSIA,
+    tier2::AARCH64_FUCHSIA,
     tier2::AARCH64_UNKNOWN_LINUX_GNU,
     tier2::AARCH64_UNKNOWN_LINUX_MUSL,
     tier2::ARM_LINUX_ANDROIDEABI,
@@ -75,7 +76,6 @@ pub const ALL_PLATFORMS: &[Platform] = &[
     tier2::ARMV5TE_UNKNOWN_LINUX_GNUEABI,
     tier2::ARMV7_APPLE_IOS,
     tier2::ARMV7_LINUX_ANDROIDEABI,
-    tier2::ARMV7_UNKNOWN_CLOUDABI_EABIHF,
     tier2::ARMV7_UNKNOWN_LINUX_GNUEABIHF,
     tier2::ARMV7_UNKNOWN_LINUX_MUSLEABIHF,
     tier2::ARMV7S_APPLE_IOS,
@@ -85,7 +85,6 @@ pub const ALL_PLATFORMS: &[Platform] = &[
     tier2::I586_UNKNOWN_LINUX_GNU,
     tier2::I586_UNKNOWN_LINUX_MUSL,
     tier2::I686_LINUX_ANDROID,
-    tier2::I686_UNKNOWN_CLOUDABI,
     tier2::I686_UNKNOWN_FREEBSD,
     tier2::I686_UNKNOWN_LINUX_MUSL,
     tier2::MIPS_UNKNOWN_LINUX_GNU,
@@ -108,14 +107,20 @@ pub const ALL_PLATFORMS: &[Platform] = &[
     tier2::X86_64_SUN_SOLARIS,
     tier2::X86_64_UNKNOWN_CLOUDABI,
     tier2::X86_64_UNKNOWN_FREEBSD,
-    tier2::X86_64_UNKNOWN_FUCHSIA,
+    tier2::X86_64_FUCHSIA,
     tier2::X86_64_UNKNOWN_LINUX_GNUX32,
     tier2::X86_64_UNKNOWN_LINUX_MUSL,
     tier2::X86_64_UNKNOWN_NETBSD,
     tier2::X86_64_UNKNOWN_REDOX,
+    // Tier 2.5
+    tier2::AARCH64_UNKNOWN_CLOUDABI,
+    tier2::ARMV7_UNKNOWN_CLOUDABI_EABIHF,
+    tier2::I686_UNKNOWN_CLOUDABI,
+    tier2::POWERPC_UNKNOWN_LINUX_GNUSPE,
+    tier2::SPARC_UNKNOWN_LINUX_GNU,
+    // Tier 3
     tier3::I686_UNKNOWN_HAIKU,
     tier3::I686_UNKNOWN_NETBSD,
-    tier3::LE32_UNKNOWN_NACL,
     tier3::MIPS_UNKNOWN_LINUX_UCLIBC,
     tier3::MIPSEL_UNKNOWN_LINUX_UCLIBC,
     tier3::MSP430_NONE_ELF,
@@ -124,6 +129,7 @@ pub const ALL_PLATFORMS: &[Platform] = &[
     tier3::THUMBV7EM_NONE_EABI,
     tier3::THUMBV7EM_NONE_EABIHF,
     tier3::THUMBV7M_NONE_EABI,
+    tier3::X86_64_FORTANIX_UNKNOWN_SGX,
     tier3::X86_64_UNKNOWN_BITRIG,
     tier3::X86_64_UNKNOWN_DRAGONFLY,
     tier3::X86_64_UNKNOWN_HAIKU,

--- a/src/platform/req.rs
+++ b/src/platform/req.rs
@@ -127,6 +127,7 @@ mod tests {
             [
                 "sparc64-unknown-linux-gnu",
                 "sparcv9-sun-solaris",
+                "sparc-unknown-linux-gnu",
                 "sparc64-unknown-netbsd"
             ]
         );

--- a/src/platform/tier2.rs
+++ b/src/platform/tier2.rs
@@ -29,11 +29,11 @@ pub const AARCH64_APPLE_IOS: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// `aarch64-unknown-cloudabi`: ARM64 CloudABI
-pub const AARCH64_UNKNOWN_CLOUDABI: Platform = Platform {
-    target_triple: "aarch64-unknown-cloudabi",
+/// `aarch64-fuchsia`: ARM64 Fuchsia
+pub const AARCH64_FUCHSIA: Platform = Platform {
+    target_triple: "aarch64-fuchsia",
     target_arch: Arch::AARCH64,
-    target_os: OS::CloudABI,
+    target_os: OS::Fuchsia,
     target_env: None,
     tier: Tier::Two,
 };
@@ -43,15 +43,6 @@ pub const AARCH64_LINUX_ANDROID: Platform = Platform {
     target_triple: "aarch64-linux-android",
     target_arch: Arch::AARCH64,
     target_os: OS::Android,
-    target_env: None,
-    tier: Tier::Two,
-};
-
-/// `aarch64-unknown-fuchsia`: ARM64 Fuchsia
-pub const AARCH64_UNKNOWN_FUCHSIA: Platform = Platform {
-    target_triple: "aarch64-unknown-fuchsia",
-    target_arch: Arch::AARCH64,
-    target_os: OS::Fuchsia,
     target_env: None,
     tier: Tier::Two,
 };
@@ -146,15 +137,6 @@ pub const ARMV7_LINUX_ANDROIDEABI: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// `armv7-unknown-cloudabi-eabihf`: ARMv7 CloudABI, hardfloat
-pub const ARMV7_UNKNOWN_CLOUDABI_EABIHF: Platform = Platform {
-    target_triple: "armv7-unknown-cloudabi-eabihf",
-    target_arch: Arch::ARM,
-    target_os: OS::CloudABI,
-    target_env: None,
-    tier: Tier::Two,
-};
-
 /// `armv7-unknown-linux-gnueabihf`: ARMv7 Linux
 pub const ARMV7_UNKNOWN_LINUX_GNUEABIHF: Platform = Platform {
     target_triple: "armv7-unknown-linux-gnueabihf",
@@ -233,15 +215,6 @@ pub const I686_LINUX_ANDROID: Platform = Platform {
     target_arch: Arch::X86,
     target_env: None,
     target_os: OS::Android,
-    tier: Tier::Two,
-};
-
-/// `i686-unknown-cloudabi`: 32-bit CloudABI
-pub const I686_UNKNOWN_CLOUDABI: Platform = Platform {
-    target_triple: "i686-unknown-cloudabi",
-    target_arch: Arch::X86,
-    target_os: OS::CloudABI,
-    target_env: None,
     tier: Tier::Two,
 };
 
@@ -398,6 +371,15 @@ pub const X86_64_APPLE_IOS: Platform = Platform {
     tier: Tier::Two,
 };
 
+/// `x86_64-fuchsia`: 64-bit x86 Fuchsia
+pub const X86_64_FUCHSIA: Platform = Platform {
+    target_triple: "x86_64-fuchsia",
+    target_arch: Arch::X86_64,
+    target_os: OS::Fuchsia,
+    target_env: None,
+    tier: Tier::Two,
+};
+
 /// `x86_64-linux-android`: 64-bit x86 Android
 pub const X86_64_LINUX_ANDROID: Platform = Platform {
     target_triple: "x86_64-linux-android",
@@ -443,15 +425,6 @@ pub const X86_64_UNKNOWN_FREEBSD: Platform = Platform {
     tier: Tier::Two,
 };
 
-/// `x86_64-unknown-fuchsia`: 64-bit Fuchsia
-pub const X86_64_UNKNOWN_FUCHSIA: Platform = Platform {
-    target_triple: "x86_64-unknown-fuchsia",
-    target_arch: Arch::X86_64,
-    target_os: OS::Fuchsia,
-    target_env: None,
-    tier: Tier::Two,
-};
-
 /// `x86_64-unknown-linux-gnux32`: 64-bit Linux
 pub const X86_64_UNKNOWN_LINUX_GNUX32: Platform = Platform {
     target_triple: "x86_64-unknown-linux-gnux32",
@@ -485,5 +458,67 @@ pub const X86_64_UNKNOWN_REDOX: Platform = Platform {
     target_arch: Arch::X86_64,
     target_env: None,
     target_os: OS::Redox,
+    tier: Tier::Two,
+};
+
+//
+// Tier 2.5 platforms
+//
+// Tier 2.5 platforms can be thought of as “guaranteed to build”, but without
+// builds available through rustup. Automated tests are not run so it’s not
+// guaranteed to produce a working build, but platforms often work to quite a
+// good degree and patches are always welcome! Specifically, these platforms
+// are required to have each of the following:
+//
+// - Automated building is set up, but may not be running tests.
+// - Landing changes to the rust-lang/rust repository’s master branch is gated
+//   on platforms building. For some platforms only the standard library is
+//   compiled, but for others rustc and cargo are too.
+//
+// **This status is accidental: no new platforms should reach this state**
+//
+
+/// `aarch64-unknown-cloudabi`: ARM64 CloudABI
+pub const AARCH64_UNKNOWN_CLOUDABI: Platform = Platform {
+    target_triple: "aarch64-unknown-cloudabi",
+    target_arch: Arch::AARCH64,
+    target_os: OS::CloudABI,
+    target_env: None,
+    tier: Tier::Two,
+};
+
+/// `armv7-unknown-cloudabi-eabihf`: ARMv7 CloudABI, hardfloat
+pub const ARMV7_UNKNOWN_CLOUDABI_EABIHF: Platform = Platform {
+    target_triple: "armv7-unknown-cloudabi-eabihf",
+    target_arch: Arch::ARM,
+    target_os: OS::CloudABI,
+    target_env: None,
+    tier: Tier::Two,
+};
+
+/// `i686-unknown-cloudabi`: 32-bit CloudABI
+pub const I686_UNKNOWN_CLOUDABI: Platform = Platform {
+    target_triple: "i686-unknown-cloudabi",
+    target_arch: Arch::X86,
+    target_os: OS::CloudABI,
+    target_env: None,
+    tier: Tier::Two,
+};
+
+/// `powerpc-unknown-linux-gnuspe`: PowerPC SPE Linux
+pub const POWERPC_UNKNOWN_LINUX_GNUSPE: Platform = Platform {
+    target_triple: "powerpc-unknown-linux-gnuspe",
+    target_arch: Arch::POWERPC,
+    target_os: OS::Linux,
+    target_env: Some(Env::GNU),
+    tier: Tier::Two,
+};
+
+/// `sparc-unknown-linux-gnu`: 32-bit SPARC Linux
+pub const SPARC_UNKNOWN_LINUX_GNU: Platform = Platform {
+    target_triple: "sparc-unknown-linux-gnu",
+    target_arch: Arch::SPARC,
+    target_os: OS::Linux,
+    target_env: Some(Env::GNU),
     tier: Tier::Two,
 };

--- a/src/platform/tier3.rs
+++ b/src/platform/tier3.rs
@@ -29,15 +29,6 @@ pub const I686_UNKNOWN_NETBSD: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// `le32-unknown-nacl`: PNaCl sandbox
-pub const LE32_UNKNOWN_NACL: Platform = Platform {
-    target_triple: "le32-unknown-nacl",
-    target_arch: Arch::Unknown, // TODO: `Arch::` for le32
-    target_os: OS::Unknown,
-    target_env: None,
-    tier: Tier::Three,
-};
-
 /// `mips-unknown-linux-uclibc`: MIPS Linux with uClibc
 pub const MIPS_UNKNOWN_LINUX_UCLIBC: Platform = Platform {
     target_triple: "mips-unknown-linux-uclibc",
@@ -77,7 +68,7 @@ pub const SPARC64_UNKNOWN_NETBSD: Platform = Platform {
 /// `thumbv6m-none-eabi`: Bare Cortex-M0, M0+, M1
 pub const THUMBV6M_NONE_EABI: Platform = Platform {
     target_triple: "thumbv6m-none-eabi",
-    target_arch: Arch::Unknown, // TODO: `Arch::` for thumbv6
+    target_arch: Arch::THUMBV6,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Three,
@@ -86,7 +77,7 @@ pub const THUMBV6M_NONE_EABI: Platform = Platform {
 /// `thumbv7em-none-eabi`:	Bare Cortex-M4, M7
 pub const THUMBV7EM_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7em-none-eabi",
-    target_arch: Arch::Unknown, // TODO: `Arch::` for thumbv7
+    target_arch: Arch::THUMBV7,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Three,
@@ -95,7 +86,7 @@ pub const THUMBV7EM_NONE_EABI: Platform = Platform {
 /// `thumbv7em-none-eabihf`: Bare Cortex-M4F, M7F, FPU, hardfloat
 pub const THUMBV7EM_NONE_EABIHF: Platform = Platform {
     target_triple: "thumbv7em-none-eabihf",
-    target_arch: Arch::Unknown, // TODO: `Arch::` for thumbv7
+    target_arch: Arch::THUMBV7,
     target_os: OS::Unknown,
     target_env: None,
     tier: Tier::Three,
@@ -104,9 +95,18 @@ pub const THUMBV7EM_NONE_EABIHF: Platform = Platform {
 /// `thumbv7m-none-eabi`: Bare Cortex-M3
 pub const THUMBV7M_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7m-none-eabi",
-    target_arch: Arch::Unknown, // TODO: `Arch::` for thumbv7
+    target_arch: Arch::THUMBV7,
     target_os: OS::Unknown,
     target_env: None,
+    tier: Tier::Three,
+};
+
+/// `x86_64-fortanix-unknown-sgx`: 	Fortanix ABI for 64-bit Intel SGX
+pub const X86_64_FORTANIX_UNKNOWN_SGX: Platform = Platform {
+    target_triple: "x86_64-fortanix-unknown-sgx",
+    target_arch: Arch::X86_64,
+    target_os: OS::Unknown,
+    target_env: Some(Env::SGX),
     tier: Tier::Three,
 };
 

--- a/src/target/arch.rs
+++ b/src/target/arch.rs
@@ -37,16 +37,25 @@ pub enum Arch {
     /// `s390x`: 64-bit IBM z/Architecture
     S390X,
 
+    /// `sparc`: 32-bit SPARC CPU architecture
+    SPARC,
+
     /// `sparc64`: 64-bit SPARC CPU architecture
     SPARC64,
+
+    /// `thumbv6`: 16-bit ARM CPU architecture subset
+    THUMBV6,
+
+    /// `thumbv7`: 16-bit ARM CPU architecture subset
+    THUMBV7,
 
     /// `wasm32`: Web Assembly (32-bit)
     WASM32,
 
-    /// `x86`: Generic x86 architecture
+    /// `x86`: Generic x86 CPU architecture
     X86,
 
-    /// `x86_64`: "AMD64" architecture
+    /// `x86_64`: "AMD64" CPU architecture
     X86_64,
 
     /// Unknown CPU architecture
@@ -67,7 +76,10 @@ impl Arch {
             Arch::POWERPC64 => "powerpc64",
             Arch::RISCV => "riscv",
             Arch::S390X => "s390x",
+            Arch::SPARC => "sparc",
             Arch::SPARC64 => "sparc64",
+            Arch::THUMBV6 => "thumbv6",
+            Arch::THUMBV7 => "thumbv7",
             Arch::WASM32 => "wasm32",
             Arch::X86 => "x86",
             Arch::X86_64 => "x86_64",
@@ -92,7 +104,10 @@ impl FromStr for Arch {
             "powerpc64" => Arch::POWERPC64,
             "riscv" => Arch::RISCV,
             "s390x" => Arch::S390X,
+            "sparc" => Arch::SPARC,
             "sparc64" => Arch::SPARC64,
+            "thumbv6" => Arch::THUMBV6,
+            "thumbv7" => Arch::THUMBV7,
             "wasm32" => Arch::WASM32,
             "x86" => Arch::X86,
             "x86_64" => Arch::X86_64,
@@ -160,6 +175,10 @@ pub const TARGET_ARCH: Arch = Arch::RISCV;
 /// `target_arch` when building this crate: `s390x`
 pub const TARGET_ARCH: Arch = Arch::S390X;
 
+#[cfg(target_arch = "sparc")]
+/// `target_arch` when building this crate: `sparc`
+pub const TARGET_ARCH: Arch = Arch::SPARC;
+
 #[cfg(target_arch = "sparc64")]
 /// `target_arch` when building this crate: `sparc64`
 pub const TARGET_ARCH: Arch = Arch::SPARC64;
@@ -186,6 +205,7 @@ pub const TARGET_ARCH: Arch = Arch::X86_64;
     target_arch = "powerpc64",
     target_arch = "riscv",
     target_arch = "s390x",
+    target_arch = "sparc",
     target_arch = "sparc64",
     target_arch = "wasm32",
     target_arch = "x86",

--- a/src/target/env.rs
+++ b/src/target/env.rs
@@ -19,6 +19,9 @@ pub enum Env {
     /// `musl`: Clean, efficient, standards-conformant libc implementation.
     Musl,
 
+    /// `sgx`: Intel Software Guard Extensions (SGX) Enclave
+    SGX,
+
     /// `uclibc`: C library for developing embedded Linux systems
     #[allow(non_camel_case_types)]
     uClibc,
@@ -34,6 +37,7 @@ impl Env {
             Env::GNU => "gnu",
             Env::MSVC => "msvc",
             Env::Musl => "musl",
+            Env::SGX => "sgx",
             Env::uClibc => "uclibc",
             Env::Unknown => "unknown",
         }
@@ -49,6 +53,7 @@ impl FromStr for Env {
             "gnu" => Env::GNU,
             "msvc" => Env::MSVC,
             "musl" => Env::Musl,
+            "sgx" => Env::SGX,
             "uclibc" => Env::uClibc,
             _ => return Err(Error),
         };
@@ -86,6 +91,10 @@ pub const TARGET_ENV: Option<Env> = Some(Env::MSVC);
 /// `target_env` when building this crate: `musl`
 pub const TARGET_ENV: Option<Env> = Some(Env::Musl);
 
+#[cfg(target_env = "sgx")]
+/// `target_env` when building this crate: `sgx`
+pub const TARGET_ENV: Option<Env> = Some(Env::SGX);
+
 #[cfg(target_env = "uclibc")]
 /// `target_env` when building this crate: `uclibc`
 pub const TARGET_ENV: Option<Env> = Some(Env::uClibc);
@@ -94,6 +103,7 @@ pub const TARGET_ENV: Option<Env> = Some(Env::uClibc);
     target_env = "gnu",
     target_env = "msvc",
     target_env = "musl",
+    target_env = "sgx",
     target_env = "uclibc",
 )))]
 /// `target_env` when building this crate: none


### PR DESCRIPTION
Matches the current platform list (as of today) sourced from:

https://forge.rust-lang.org/platform-support.html

(Curiously there are no `riscv`/`riscv32` targets on here?)