### PR TITLE
Properly set up target::os::TARGET_OS const for unknown OS

### DIFF
--- a/src/target/os.rs
+++ b/src/target/os.rs
@@ -214,5 +214,5 @@ pub const TARGET_OS: OS = OS::Windows;
     target_os = "solaris",
     target_os = "windows",
 )))]
-/// `target_env` when building this crate: unknown!
-pub const TARGET_ENV: OS = OS::Unknown;
+/// `target_os` when building this crate: unknown!
+pub const TARGET_OS: OS = OS::Unknown;


### PR DESCRIPTION
For known OS types `crate::target::os` module provides the `TARGET_OS` const with a target OS value,
but for unknown types (such as `wasm32-unknown-unknown`) `pub const TARGET_ENV: Os = ..` is declared instead: https://github.com/RustSec/platforms-crate/blob/2feb4c6bfddf11148a72a3d5e2e8a3a3b924982d/src/target/os.rs#L217-L218

```bash
$ cargo check --target=wasm32-unknown-unknown                                     
    Checking platforms v0.2.0 (/home/svartalf/projects/platforms-crate)
error[E0432]: unresolved import `self::os::TARGET_OS`
  --> src/target/mod.rs:13:14
   |
13 |     os::{OS, TARGET_OS},
   |              ^^^^^^^^^
   |              |
   |              no `TARGET_OS` in `target::os`
   |              help: a similar name exists in the module: `TARGET_ENV`

error: aborting due to previous error
```

I believe this is a mistype and `TARGET_OS` const should be declared here. This PR fixes it.

EDIT: It should be `wasm32-wasi` target instead in the example above, actually, but it still has the same problem.