### PR TITLE
v0.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.2.1] (2019-09-24)
+
+- Initial GitHub Actions config ([#12])
+- Properly set up `target::os::TARGET_OS` const for unknown OS ([#11])
+
 ## [0.2.0] (2019-01-13)
 
 - Update platforms to match RustForge ([#9])
@@ -29,6 +34,9 @@
 
 - Initial release
 
+[0.2.1]: https://github.com/RustSec/platforms-crate/pull/13
+[#12]: https://github.com/RustSec/platforms-crate/pull/12
+[#11]: https://github.com/RustSec/platforms-crate/pull/11
 [0.2.0]: https://github.com/RustSec/platforms-crate/pull/10
 [#9]: https://github.com/RustSec/platforms-crate/pull/9
 [#8]: https://github.com/RustSec/platforms-crate/pull/8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from Rust Forge.
 """
-version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "MIT OR Apache-2.0"
 homepage    = "https://github.com/RustSec/platforms-crate"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
     unused_qualifications
 )]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/platforms/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/platforms/0.2.1")]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
- Initial GitHub Actions config (#12)
- Properly set up `target::os::TARGET_OS` const for unknown OS (#11)