### PR TITLE
Make extensible enums `non_exhaustive`; MSRV 1.40+

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,33 +1,45 @@
-# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+name: Rust
 
 on:
   pull_request: {}
   push:
-    branches: develop
+    branches: master
 
-name: Rust
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   test:
-    name: Test Suite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.40.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --all-features
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --all-features
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.40.0 # MSRV
+          components: clippy
+      - run: cargo clippy --all --all-features -- -D warnings
+
+  rustfmt:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -36,54 +48,12 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: stable
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
+          components: rustfmt
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Install clippy
-        run: rustup component add clippy
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ description = """
 Rust platform registry with information about valid Rust platforms (target
 triple, target_arch, target_os) sourced from Rust Forge.
 """
-version     = "0.2.1" # Also update html_root_url in lib.rs when bumping this
-authors     = ["Tony Arcieri <bascule@gmail.com>"]
-license     = "Apache-2.0 OR MIT"
-homepage    = "https://rustsec.org"
-repository  = "https://github.com/RustSec/platforms-crate"
-readme      = "README.md"
-categories  = ["development-tools", "no-std"]
-keywords    = ["architectures", "cpu", "platforms", "os", "targets"]
-edition     = "2018"
+version    = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+authors    = ["Tony Arcieri <bascule@gmail.com>"]
+license    = "Apache-2.0 OR MIT"
+homepage   = "https://rustsec.org"
+repository = "https://github.com/RustSec/platforms-crate"
+readme     = "README.md"
+categories = ["development-tools", "no-std"]
+keywords   = ["architectures", "cpu", "platforms", "os", "targets"]
+edition    = "2018"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/README.md
+++ b/README.md
@@ -3,40 +3,34 @@
 [![Latest Version][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Build Status][build-image]][build-link]
-![MIT/Apache 2 licensed][license-image]
-[![Gitter Chat][gitter-image]][gitter-link]
-
-[crate-image]: https://img.shields.io/crates/v/platforms.svg
-[crate-link]: https://crates.io/crates/platforms
-[docs-image]: https://docs.rs/platforms/badge.svg
-[docs-link]: https://docs.rs/platforms/
-[build-image]: https://github.com/rustsec/platforms-crate/workflows/Rust/badge.svg
-[build-link]: https://github.com/rustsec/platforms-crate/actions
-[license-image]: https://img.shields.io/badge/license-MIT%2FApache2-blue.svg
-[gitter-image]: https://badges.gitter.im/badge.svg
-[gitter-link]: https://gitter.im/RustSec/Lobby
+![Apache 2/MIT licensed][license-image]
+![MSRV][rustc-image]
+[![Project Chat][zulip-image]][zulip-link]
 
 Rust platform registry: provides programmatic access to information
 about valid Rust platforms, sourced from [Rust Forge].
 
-[Documentation]
-
-[Rust Forge]: https://forge.rust-lang.org/platform-support.html
-[Documentation]: https://docs.rs/platforms/
+[Documentation][docs-link]
 
 ## About
 
 This crate provides programmatic access to information about valid Rust
 platforms. This is useful for systems which document/inventory information
-relevant to Rust platforms: specifically it was created for the
-[RustSec Advisory Database] as a way to document and validate which Rust
-platforms security advisories are applicable to.
+relevant to Rust platforms.
+
+It was created for the [RustSec Advisory Database] and is maintained by the
+[Rust Secure Code Working Group][wg-secure-code].
 
 It is not intended to be a tool for gating builds based on the current platform
 or as a replacement for Rust's existing conditional compilation features:
 please use those for build purposes.
 
-[RustSec Advisory Database]: https://github.com/RustSec
+## Minimum Supported Rust Version
+
+Rust **1.41** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
 
 ## Registered Platforms
 
@@ -132,6 +126,44 @@ please use those for build purposes.
 | [x86_64-unknown-haiku]            | x86_64      | haiku      | ""         |
 | [x86_64-unknown-openbsd]          | x86_64      | openbsd    | ""         |
 
+## License
+
+Licensed under either of:
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE] or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT] or https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you shall be dual licensed as above, without any
+additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/platforms.svg
+[crate-link]: https://crates.io/crates/platforms
+[docs-image]: https://docs.rs/platforms/badge.svg
+[docs-link]: https://docs.rs/platforms/
+[build-image]: https://github.com/rustsec/platforms-crate/workflows/Rust/badge.svg
+[build-link]: https://github.com/rustsec/platforms-crate/actions
+[license-image]: https://img.shields.io/badge/license-MIT%2FApache2-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[zulip-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[zulip-link]: https://rust-lang.zulipchat.com/#narrow/stream/146229-wg-secure-code/
+
+[//]: # (general links)
+
+[Rust Forge]: https://forge.rust-lang.org/platform-support.html
+[RustSec Advisory Database]: https://github.com/RustSec
+[wg-secure-code]: https://www.rust-lang.org/governance/wgs/wg-secure-code
+[LICENSE-APACHE]: https://github.com/RustSec/rustsec-client/blob/master/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/RustSec/rustsec-client/blob/master/LICENSE-MIT
+
+[//]: # (platform links)
+
 [i686-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.I686_APPLE_DARWIN.html
 [i686-pc-windows-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.I686_PC_WINDOWS_GNU.html
 [i686-pc-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.I686_PC_WINDOWS_MSVC.html
@@ -209,21 +241,3 @@ please use those for build purposes.
 [x86_64-unknown-dragonfly]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.X86_64_UNKNOWN_DRAGONFLY.html
 [x86_64-unknown-haiku]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.X86_64_UNKNOWN_HAIKU.html
 [x86_64-unknown-openbsd]: https://docs.rs/platforms/latest/platforms/platform/tier3/constant.X86_64_UNKNOWN_OPENBSD.html
-
-## License
-
-Licensed under either of:
-
- * Apache License, Version 2.0 ([LICENSE-APACHE] or https://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT] or https://opensource.org/licenses/MIT)
-
-at your option.
-
-[LICENSE-APACHE]: https://github.com/RustSec/rustsec-client/blob/master/LICENSE-APACHE
-[LICENSE-MIT]: https://github.com/RustSec/rustsec-client/blob/master/LICENSE-MIT
-
-### Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you shall be dual licensed as above, without any
-additional terms or conditions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,18 +3,18 @@
 //! This crate provides an interface to the platform data available at Rust Forge:
 //!
 //! <https://forge.rust-lang.org/platform-support.html>
+//!
+//! ## Minimum Supported Rust Version
+//!
+//! Rust **1.41** or higher.
+//!
+//! Minimum supported Rust version can be changed in the future, but it will be
+//! done with a minor version bump.
 
 #![no_std]
-#![deny(
-    warnings,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_import_braces,
-    unused_qualifications
-)]
-#![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/platforms/0.2.1")]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, unused_qualifications)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/src/platform/tier3.rs
+++ b/src/platform/tier3.rs
@@ -74,7 +74,7 @@ pub const THUMBV6M_NONE_EABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// `thumbv7em-none-eabi`:	Bare Cortex-M4, M7
+/// `thumbv7em-none-eabi`: Bare Cortex-M4, M7
 pub const THUMBV7EM_NONE_EABI: Platform = Platform {
     target_triple: "thumbv7em-none-eabi",
     target_arch: Arch::THUMBV7,
@@ -101,7 +101,7 @@ pub const THUMBV7M_NONE_EABI: Platform = Platform {
     tier: Tier::Three,
 };
 
-/// `x86_64-fortanix-unknown-sgx`: 	Fortanix ABI for 64-bit Intel SGX
+/// `x86_64-fortanix-unknown-sgx`: Fortanix ABI for 64-bit Intel SGX
 pub const X86_64_FORTANIX_UNKNOWN_SGX: Platform = Platform {
     target_triple: "x86_64-fortanix-unknown-sgx",
     target_arch: Arch::X86_64,

--- a/src/target/arch.rs
+++ b/src/target/arch.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 
 /// `target_arch`: Target CPU architecture
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum Arch {
     /// `aarch64`: ARMv8 64-bit architecture
     AARCH64,

--- a/src/target/env.rs
+++ b/src/target/env.rs
@@ -9,6 +9,7 @@ use crate::error::Error;
 /// though it is not identical. For example, embedded ABIs such as `gnueabihf` will simply
 /// define `target_env` as `"gnu"` (i.e. `target::Env::GNU`)
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum Env {
     /// `gnu`: The GNU C Library (glibc)
     GNU,

--- a/src/target/os.rs
+++ b/src/target/os.rs
@@ -7,6 +7,7 @@ use crate::error::Error;
 /// `target_os`: Operating system of the target. This value is closely related to the second
 /// and third element of the platform target triple, though it is not identical.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum OS {
     /// `android`: Google's Android mobile operating system
     Android,


### PR DESCRIPTION
Adds the `#[non_exhaustive]` attribute to enums we might like to extend in the future, allowing for non-semver-breaking updates.