### PR TITLE
Add aarch64-apple-darwin to Platform list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ done with a minor version bump.
 
 | target triple                     | target_arch | target_os  | target_env |
 |-----------------------------------|-------------|------------|------------|
+| [aarch64-apple-darwin]            | aarch64     | macos      | ""         |
 | [aarch64-apple-ios]               | aarch64     | ios        | ""         |
 | [aarch64-pc-windows-msvc]         | aarch64     | windows    | msvc       |
 | [aarch64-linux-android]           | aarch64     | android    | ""         |
@@ -172,6 +173,7 @@ additional terms or conditions.
 [x86_64-pc-windows-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.X86_64_PC_WINDOWS_GNU.html
 [x86_64-pc-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.X86_64_PC_WINDOWS_MSVC.html
 [x86_64-unknown-linux-gnu]: https://docs.rs/platforms/latest/platforms/platform/tier1/constant.X86_64_UNKNOWN_LINUX_GNU.html
+[aarch64-apple-darwin]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_APPLE_DARWIN.html
 [aarch64-apple-ios]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_APPLE_IOS.html
 [aarch64-pc-windows-msvc]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_PC_WINDOWS_MSVC.html
 [aarch64-linux-android]: https://docs.rs/platforms/latest/platforms/platform/tier2/constant.AARCH64_LINUX_ANDROID.html

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -79,6 +79,7 @@ impl Platform {
             tier1::X86_64_PC_WINDOWS_MSVC,
             tier1::X86_64_UNKNOWN_LINUX_GNU,
             // Tier 2
+            tier2::AARCH64_APPLE_DARWIN,
             tier2::AARCH64_APPLE_IOS,
             tier2::AARCH64_PC_WINDOWS_MSVC,
             tier2::AARCH64_LINUX_ANDROID,

--- a/src/platform/tier2.rs
+++ b/src/platform/tier2.rs
@@ -20,6 +20,15 @@ use crate::{
     target::{Arch, Env, OS},
 };
 
+/// `aarch64-apple-darwin`: Apple Silicon macOS (11+)
+pub const AARCH64_APPLE_DARWIN: Platform = Platform {
+    target_triple: "aarch64-apple-darwin",
+    target_arch: Arch::AARCH64,
+    target_os: OS::MacOS,
+    target_env: None,
+    tier: Tier::Two,
+};
+
 /// `aarch64-apple-ios`: ARM64 iOS
 pub const AARCH64_APPLE_IOS: Platform = Platform {
     target_triple: "aarch64-apple-ios",


### PR DESCRIPTION
This PR adds Apple Silicon macOS to platform list. The triple `aarch64-apple-darwin` is available in Rust 1.49 beta (as well as a patched Rust 1.48 release in Homebrew) as a Tier-2 platform.

This should solve issues caused by project using this crates to guess the current platform, such as `PyO3/Maturin` ([ref](https://github.com/PyO3/maturin/blob/274eb3dce80262a078752cb9ec1098e60cdf4eef/src/target.rs#L91-L97)).

Closes #31 